### PR TITLE
Fix incorrect messages ref

### DIFF
--- a/.bluemix/deploy.json
+++ b/.bluemix/deploy.json
@@ -1,9 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Sample Deploy Stage",
-    "localized-struct":{
-        "$ref": "deploy-localized-struct.json"
-    },
     "description": "sample toolchain",
     "longDescription": "The Delivery Pipeline automates continuous deployment.",
     "type": "object",


### PR DESCRIPTION
Loading this template [in the Devops UI](https://console.ng.bluemix.net/devops/setup/deploy?repository=https%3A%2F%2Fgithub.com%2FIBMCloudDevOps%2Fbluemix-kubernetes-sample) produces an error:

![error](https://cloud.githubusercontent.com/assets/382404/24972440/6d85ad5a-1f89-11e7-8bdc-ef0c32ae0216.png)

The cause is a reference to a missing file `deploy-localized-struct.json`. Older versions of the UI would not notice this, but it has become stricter since then.

This pull request fixes the problem